### PR TITLE
Updated support for engine styles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.2] - 2026-06-10
+
+### Added
+
+- `platypus.css` shipped in the npm tarball under `lib/` and exposed as `@makefully/platypus/platypus.css` (release build copies `src/platypus.css`).
+
+### Changed
+
+- README documents the supported CSS import path for npm consumers (replaces v3 `src/platypus.css` imports).
+
 ## [4.1.1] - 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Optional: `box2d3-wasm`, `jsmediatags`, `poly-decomp` (see `optionalDependencies
 
 Entry point: `lib/platypus.js` (plus any worker chunks emitted alongside it in `lib/`).
 
+Include the engine stylesheet in your game's CSS (canvas layout, captions, debug overlay):
+
+```css
+@import '@makefully/platypus/platypus.css';
+```
+
 ## Development
 
 Requires **Node.js 20+**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ PLATYPUS_DOCS_REPO=git@github.com:Makefully-Studios/platypus.git npm run docs:pu
 
 ## npm package
 
-The library is published as [`@makefully/platypus`](https://www.npmjs.com/package/@makefully/platypus). The tarball includes everything under `lib/` (UMD bundle and any worker chunks from `npm run build:release`), not `src/`. The `lib/` directory is gitignored in this repo; `prepack` rebuilds it when you publish to npm.
+The library is published as [`@makefully/platypus`](https://www.npmjs.com/package/@makefully/platypus). The tarball includes everything under `lib/` (UMD bundle, `platypus.css`, and any worker chunks from `npm run build:release`), not `src/`. The `lib/` directory is gitignored in this repo; `prepack` rebuilds it when you publish to npm. Consumers import styles via `@makefully/platypus/platypus.css`.
 
 ```bash
 npm run build:release   # Webpack 5 production build → lib/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makefully/platypus",
-    "version": "4.1.1",
+    "version": "4.1.2",
     "description": "2D tile-based HTML5 game engine with a component-based entity model",
     "license": "MIT",
     "contributors": [
@@ -10,6 +10,7 @@
     "main": "lib/platypus.js",
     "exports": {
         ".": "./lib/platypus.js",
+        "./platypus.css": "./lib/platypus.css",
         "./package.json": "./package.json"
     },
     "files": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,17 @@
+const fs = require('fs');
 const path = require('path');
+
+class CopyPlatypusCssPlugin {
+    apply (compiler) {
+        compiler.hooks.afterEmit.tap('CopyPlatypusCssPlugin', (compilation) => {
+            const
+                from = path.join(__dirname, 'src/platypus.css'),
+                to = path.join(compilation.outputOptions.path, 'platypus.css');
+
+            fs.copyFileSync(from, to);
+        });
+    }
+}
 
 module.exports = (env, argv) => {
     const
@@ -31,6 +44,9 @@ module.exports = (env, argv) => {
             '@pixi/sound': '@pixi/sound',
             'pixi.js': 'pixi.js',
             springroll: 'springroll'
-        }
+        },
+        plugins: [
+            new CopyPlatypusCssPlugin()
+        ]
     };
 };


### PR DESCRIPTION
### Added

- `platypus.css` shipped in the npm tarball under `lib/` and exposed as `@makefully/platypus/platypus.css` (release build copies `src/platypus.css`).

### Changed

- README documents the supported CSS import path for npm consumers (replaces v3 `src/platypus.css` imports).