### PR TITLE
Bumped actions to node 24 and added auto-npm-release.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies
@@ -30,7 +30,7 @@ jobs:
         run: npm run docs
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,94 +1,113 @@
-name: Release
-
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
-permissions:
-  contents: write
-
-jobs:
-  detect-version:
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
-      version: ${{ steps.check.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Detect version bump
-        id: check
-        run: |
-          CURRENT=$(node -p "require('./package.json').version")
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
-            echo "Manual run: releasing $CURRENT"
-            exit 0
-          fi
-          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          PREVIOUS=$(git show HEAD^:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
-          if [ "$PREVIOUS" = "$CURRENT" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
-          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "package.json version: $PREVIOUS -> $CURRENT"
-
-  release:
-    needs: detect-version
-    if: needs.detect-version.outputs.changed == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build release bundle
-        run: npm run build:release
-
-      - name: Write release notes
-        run: node scripts/extract-changelog.mjs "${{ needs.detect-version.outputs.version }}" > release-notes.md
-
-      - name: Skip if release already exists
-        id: exists
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          TAG="v${{ needs.detect-version.outputs.version }}"
-          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Release $TAG already exists; skipping."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create GitHub release
-        if: steps.exists.outputs.skip != 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.detect-version.outputs.version }}
-          name: ${{ needs.detect-version.outputs.version }}
-          body_path: release-notes.md
-          files: lib/*.js
-          fail_on_unmatched_files: true
-          generate_release_notes: false
-          make_latest: true
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  detect-version:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect version bump
+        id: check
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+            echo "Manual run: releasing $CURRENT"
+            exit 0
+          fi
+          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PREVIOUS=$(git show HEAD^:package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
+          if [ "$PREVIOUS" = "$CURRENT" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "version=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "package.json version: $PREVIOUS -> $CURRENT"
+
+  release:
+    needs: detect-version
+    if: needs.detect-version.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build release bundle
+        run: npm run build:release
+
+      - name: Write release notes
+        run: node scripts/extract-changelog.mjs "${{ needs.detect-version.outputs.version }}" > release-notes.md
+
+      - name: Skip if release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ needs.detect-version.outputs.version }}"
+          if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG already exists; skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if npm version already exists
+        id: npm_exists
+        run: |
+          VERSION="${{ needs.detect-version.outputs.version }}"
+          if npm view "@makefully/platypus@${VERSION}" version >/dev/null 2>&1; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "@makefully/platypus@${VERSION} already on npm; skipping publish."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.npm_exists.outputs.skip != 'true'
+        run: npm publish --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.exists.outputs.skip != 'true'
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: v${{ needs.detect-version.outputs.version }}
+          name: ${{ needs.detect-version.outputs.version }}
+          body_path: release-notes.md
+          files: lib/*.js
+          fail_on_unmatched_files: true
+          generate_release_notes: false
+          make_latest: true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.3] - 2026-06-10
+
+### Added
+
+- Release workflow publishes `@makefully/platypus` to npm when `package.json` version changes on `main` (requires `NPM_TOKEN` repository secret).
+
+### Changed
+
+- GitHub Actions workflows use Node.js 24 and action versions with a Node 24 runtime (`actions/checkout@v6`, `actions/setup-node@v6`, `softprops/action-gh-release@v3`, `peaceiris/actions-gh-pages@v4.1.0`).
+
 ## [4.1.2] - 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run docs            # API reference → docs/api/ (gitignored)
 
 Contributor workflow, API docs publishing, and `npm publish` are described in [docs/README.md](docs/README.md).
 
-When `package.json` **version** changes on `main`, [.github/workflows/release.yml](.github/workflows/release.yml) builds `lib/*.js`, reads the matching [CHANGELOG.md](CHANGELOG.md) section, and publishes a GitHub release (skips if that tag already exists).
+When `package.json` **version** changes on `main`, [.github/workflows/release.yml](.github/workflows/release.yml) builds `lib/`, publishes to [npm](https://www.npmjs.com/package/@makefully/platypus), and creates a GitHub release from the matching [CHANGELOG.md](CHANGELOG.md) section (skips each step if that version already exists).
 
 ## Key Features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,13 @@ npm run pack:check      # preview tarball contents
 npm publish             # runs prepack, then publishes
 ```
 
-Requires npm login with access to the `@makefully` scope (`publishConfig.access` is `public`).
+### Automated publish (CI)
+
+When `package.json` **version** changes on `main`, [.github/workflows/release.yml](../.github/workflows/release.yml) builds `lib/`, publishes `@makefully/platypus` to npm, and creates a matching GitHub release. Each step is skipped independently if that version is already on npm or GitHub.
+
+One-time setup: add an npm [granular access token](https://docs.npmjs.com/creating-and-viewing-access-tokens) with **Publish** permission for `@makefully/platypus` as the repository secret **`NPM_TOKEN`**.
+
+Manual publish still works with npm login and access to the `@makefully` scope (`publishConfig.access` is `public`).
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makefully/platypus",
-    "version": "4.1.2",
+    "version": "4.1.3",
     "description": "2D tile-based HTML5 game engine with a component-based entity model",
     "license": "MIT",
     "contributors": [


### PR DESCRIPTION
### Added

- Release workflow publishes `@makefully/platypus` to npm when `package.json` version changes on `main` (requires `NPM_TOKEN` repository secret).

### Changed

- GitHub Actions workflows use Node.js 24 and action versions with a Node 24 runtime (`actions/checkout@v6`, `actions/setup-node@v6`, `softprops/action-gh-release@v3`, `peaceiris/actions-gh-pages@v4.1.0`).
