### PR TITLE
Bumped to v4.1.5 with ESM import entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.5] - 2026-06-10
+
+### Added
+
+- ESM build (`lib/platypus.mjs`) as the `import` entry in `package.json` exports; UMD (`lib/platypus.js`) remains the `require` entry.
+
+### Fixed
+
+- Pixi `collectRenderablesWithEffects` crash (`Cannot read properties of undefined (reading 'push')`) when consuming the npm package instead of `/src`: the prebuilt UMD hid Platypus's `pixi.js` sub-imports, so bundlers could omit mask/render pipes that masked sprites need. The ESM entry preserves those imports in the consumer's module graph.
+
 ## [4.1.4] - 2026-06-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Platypus uses:
 npm install @makefully/platypus
 ```
 
-The npm package ships a **Webpack 5 UMD build** in `lib/` (not `src/`). Your game must also install peer dependencies and expose them to the bundle (same as a classic script-tag setup):
+The npm package ships **Webpack 5 builds** in `lib/` (not `src/`): `platypus.mjs` for `import` (recommended) and `platypus.js` (UMD) for `require` or script tags. Your game must also install peer dependencies:
 
 | Package | Notes |
 |---------|--------|
@@ -30,7 +30,9 @@ The npm package ships a **Webpack 5 UMD build** in `lib/` (not `src/`). Your gam
 
 Optional: `box2d3-wasm`, `jsmediatags`, `poly-decomp` (see `optionalDependencies` in [package.json](package.json)).
 
-Entry point: `lib/platypus.js` (plus any worker chunks emitted alongside it in `lib/`).
+Entry points: `lib/platypus.mjs` (`import`) or `lib/platypus.js` (`require`/script tag), plus worker chunks alongside them in `lib/`.
+
+If you see a Pixi error like `Cannot read properties of undefined (reading 'push')` in `collectRenderablesMixin` when using the UMD build, switch to the ESM entry (`import platypus from '@makefully/platypus'`). The ESM build keeps Platypus's `pixi.js` imports visible to your bundler so mask and render pipes are initialized. Using `/src` directly worked because your bundler already walked those imports.
 
 Include the engine stylesheet in your game's CSS (canvas layout, captions, debug overlay):
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,7 @@ PLATYPUS_DOCS_REPO=git@github.com:Makefully-Studios/platypus.git npm run docs:pu
 
 ## npm package
 
-The library is published as [`@makefully/platypus`](https://www.npmjs.com/package/@makefully/platypus). The tarball includes everything under `lib/` (UMD bundle, `platypus.css`, and any worker chunks from `npm run build:release`), not `src/`. The `lib/` directory is gitignored in this repo; `prepack` rebuilds it when you publish to npm. Consumers import styles via `@makefully/platypus/platypus.css`.
+The library is published as [`@makefully/platypus`](https://www.npmjs.com/package/@makefully/platypus). The tarball includes everything under `lib/` (ESM and UMD bundles, `platypus.css`, and worker chunks from `npm run build:release`), not `src/`. The `lib/` directory is gitignored in this repo; `prepack` rebuilds it when you publish to npm. Consumers import styles via `@makefully/platypus/platypus.css`.
 
 ```bash
 npm run build:release   # Webpack 5 production build → lib/
@@ -75,4 +75,4 @@ Manual publish with `npm login` and access to the `@makefully` scope (`publishCo
 
 - [jsDoc.json](../jsDoc.json) — source paths, Minami template, output directory
 - [package.json](../package.json) — build, test, docs, and `prepack` scripts
-- [webpack.config.js](../webpack.config.js) — Webpack 5 UMD bundle to `lib/`
+- [webpack.config.js](../webpack.config.js) — Webpack 5 ESM + UMD bundles to `lib/`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makefully/platypus",
-    "version": "4.1.4",
+    "version": "4.1.5",
     "description": "2D tile-based HTML5 game engine with a component-based entity model",
     "license": "MIT",
     "contributors": [
@@ -8,8 +8,12 @@
         "Todd Lewis <todd.lewis@gopherwoodstudios.com> (https://github.com/GopherwoodTodd)"
     ],
     "main": "lib/platypus.js",
+    "module": "lib/platypus.mjs",
     "exports": {
-        ".": "./lib/platypus.js",
+        ".": {
+            "import": "./lib/platypus.mjs",
+            "require": "./lib/platypus.js"
+        },
         "./platypus.css": "./lib/platypus.css",
         "./package.json": "./package.json"
     },
@@ -43,8 +47,8 @@
     ],
     "scripts": {
         "start": "webpack serve --mode development",
-        "build:release": "webpack --mode production",
-        "build:debug": "webpack --mode development",
+        "build:release": "node scripts/clean-lib.mjs && webpack --mode production",
+        "build:debug": "node scripts/clean-lib.mjs && webpack --mode development",
         "prepack": "npm run build:release",
         "pack:check": "npm pack --dry-run",
         "test:watch": "vitest",

--- a/scripts/clean-lib.mjs
+++ b/scripts/clean-lib.mjs
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const lib = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'lib');
+
+fs.rmSync(lib, {recursive: true, force: true});
+fs.mkdirSync(lib);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,40 +13,72 @@ class CopyPlatypusCssPlugin {
     }
 }
 
-module.exports = (env, argv) => {
-    const
-        mode = argv.mode || 'production';
-
-    return {
+const
+    externals = {
+        '@esotericsoftware/spine-pixi-v8': '@esotericsoftware/spine-pixi-v8',
+        '@tweenjs/tween.js': '@tweenjs/tween.js',
+        '@pixi/sound': '@pixi/sound',
+        'pixi.js': 'pixi.js',
+        springroll: 'springroll'
+    },
+    shared = {
         entry: './src/index.js',
-        mode,
-        output: {
-            path: path.resolve(__dirname, 'lib'),
-            filename: 'platypus.js',
-            clean: true,
-            library: {
-                name: 'platypus',
-                type: 'umd',
-                umdNamedDefine: true
-            },
-            globalObject: 'typeof self !== \'undefined\' ? self : this'
-        },
-        devtool: mode === 'development' ? 'source-map' : false,
         devServer: {
             static: {
                 directory: path.join(__dirname, '.')
             },
             hot: true
         },
-        externals: {
-            '@esotericsoftware/spine-pixi-v8': '@esotericsoftware/spine-pixi-v8',
-            '@tweenjs/tween.js': '@tweenjs/tween.js',
-            '@pixi/sound': '@pixi/sound',
-            'pixi.js': 'pixi.js',
-            springroll: 'springroll'
-        },
+        externals,
         plugins: [
             new CopyPlatypusCssPlugin()
         ]
     };
+
+module.exports = (env, argv) => {
+    const
+        mode = argv.mode || 'production',
+        devtool = mode === 'development' ? 'source-map' : false;
+
+  return [
+        {
+            ...shared,
+            name: 'umd',
+            mode,
+            devtool,
+            output: {
+                path: path.resolve(__dirname, 'lib'),
+                filename: 'platypus.js',
+                library: {
+                    name: 'platypus',
+                    type: 'umd',
+                    umdNamedDefine: true
+                },
+                globalObject: 'typeof self !== \'undefined\' ? self : this'
+            }
+        },
+        {
+            ...shared,
+            name: 'esm',
+            mode,
+            devtool,
+            experiments: {
+                outputModule: true
+            },
+            output: {
+                path: path.resolve(__dirname, 'lib'),
+                filename: 'platypus.mjs',
+                chunkFilename: '[id].platypus.mjs',
+                library: {
+                    type: 'module'
+                },
+                module: true,
+                chunkFormat: 'module',
+                environment: {
+                    module: true
+                }
+            },
+            externalsType: 'module'
+        }
+    ];
 };


### PR DESCRIPTION
### Added

- ESM build (`lib/platypus.mjs`) as the `import` entry in `package.json` exports; UMD (`lib/platypus.js`) remains the `require` entry.

### Fixed

- Pixi `collectRenderablesWithEffects` crash (`Cannot read properties of undefined (reading 'push')`) when consuming the npm package instead of `/src`: the prebuilt UMD hid Platypus's `pixi.js` sub-imports, so bundlers could omit mask/render pipes that masked sprites need. The ESM entry preserves those imports in the consumer's module graph.