### PR TITLE
Updates to asset management and LevelBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.11] - 2026-06-25
+
+### Added
+
+- **PIXIAnimation:** `invalidateTextureSources` clears cached texture sources when an asset is unloaded.
+- Unit tests for `PIXIAnimation` sprite sheet cache ids and texture source invalidation.
+
+### Fixed
+
+- **LevelBuilder:** Throws informative errors when `levelPieces` or `levelTemplate` are incomplete or invalid (missing levels, empty rows, non-rectangular templates, incomplete level definitions) instead of generic undefined property errors.
+- **PIXIAnimation:** Resolves texture assets by full path or image basename; updates cached texture sources when the underlying asset changes; sprite sheet cache ids use content hashes instead of truncated JSON to avoid collisions.
+- **AssetManager:** Invalidates `PIXIAnimation` texture sources when unloading assets.
+- **Render / RenderSprite:** `getAssetList` registers image aliases via `getFileId` for webpack URL resolution.
+
 ## [4.1.10] - 2026-06-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@makefully/platypus",
-    "version": "4.1.10",
+    "version": "4.1.11",
     "description": "2D tile-based HTML5 game engine with a component-based entity model",
     "license": "MIT",
     "contributors": [

--- a/src/AssetManager.js
+++ b/src/AssetManager.js
@@ -7,6 +7,7 @@
 /* global platypus, setTimeout */
 import Data from './Data.js';
 import DataMap from './DataMap.js';
+import PIXIAnimation from './PIXIAnimation.js';
 import {Assets} from 'pixi.js';
 import {arrayCache} from './utils/array.js';
 
@@ -58,6 +59,7 @@ export default class AssetManager {
                     asset.src = '';
                 }
                 assets.delete(alias);
+                PIXIAnimation.invalidateTextureSources(alias);
             }
 
             return !counts[alias];

--- a/src/PIXIAnimation.js
+++ b/src/PIXIAnimation.js
@@ -4,15 +4,74 @@ import {arrayCache, greenSlice} from './utils/array.js';
 import Data from './Data.js';
 
 const
-    MAX_KEY_LENGTH_PER_IMAGE = 128,
     animationCache = {},
     textureSourceCache = {},
     doNothing = function () {},
     emptyFrame = Texture.EMPTY,
-    regex = /[\[\]{},-]/g,
+    imageBasename = /([\w-\.]+)\.(\w+)$/,
+    hashString = function (value) {
+        const
+            str = typeof value === 'string' ? value : JSON.stringify(value);
+        let hash = 5381;
+
+        for (let i = 0; i < str.length; i++) {
+            hash = ((hash << 5) + hash) ^ str.charCodeAt(i);
+        }
+
+        return (hash >>> 0).toString(36);
+    },
+    getTextureCacheKey = function (path) {
+        return platypus.assetCache?.getFileId ? platypus.assetCache.getFileId(path) : path;
+    },
+    resolveTextureAsset = function (path) {
+        const
+            assetCache = platypus.assetCache;
+
+        if (!assetCache) {
+            return null;
+        }
+
+        let asset = assetCache.get(path);
+
+        if (asset) {
+            return asset;
+        }
+
+        const
+            basename = typeof path === 'string' ? path.match(imageBasename) : null;
+
+        if (basename) {
+            asset = assetCache.get(basename[1]);
+
+            if (asset) {
+                return asset;
+            }
+        }
+
+        return null;
+    },
+    getTextureSourceAliases = function (alias) {
+        const
+            aliases = arrayCache.setUp(alias),
+            basename = typeof alias === 'string' ? alias.match(imageBasename) : null;
+
+        if (platypus.assetCache?.getFileId) {
+            const
+                fileId = platypus.assetCache.getFileId(alias);
+
+            if (fileId !== alias) {
+                aliases.push(fileId);
+            }
+        }
+
+        if (basename) {
+            aliases.push(basename[1]);
+        }
+
+        return aliases;
+    },
     getTextureSources = function (images) {
         const
-            assetCache = platypus.assetCache,
             bts = arrayCache.setUp();
         
         for (let i = 0; i < images.length; i++) {
@@ -20,17 +79,21 @@ const
                 path = images[i];
 
             if (typeof path === 'string') {
-                if (!textureSourceCache[path]) {
-                    const
-                        asset = assetCache.get(path);
+                const
+                    cacheKey = getTextureCacheKey(path),
+                    asset = resolveTextureAsset(path);
 
-                    if (!asset) {
-                        platypus.debug.warn(`PIXIAnimation: "${path}" is not a loaded asset.`);
-                        break;
-                    }
-                    textureSourceCache[path] = asset.source;
+                if (!asset) {
+                    delete textureSourceCache[cacheKey];
+                    platypus.debug.warn(`PIXIAnimation: "${path}" is not a loaded asset.`);
+                    break;
                 }
-                bts.push(textureSourceCache[path]);
+
+                if (textureSourceCache[cacheKey] !== asset.source) {
+                    textureSourceCache[cacheKey] = asset.source;
+                }
+
+                bts.push(textureSourceCache[cacheKey]);
             } else {
                 bts.push(new TextureSource(path));
             }
@@ -49,9 +112,7 @@ const
             }
         }
         
-        spriteSheet.id = JSON.stringify(spriteSheet).replace(regex, '');
-
-        return spriteSheet.id;
+        return `ss-${hashString(spriteSheet)}`;
     },
     getDefaultAnimation = function (length, textures) {
         const
@@ -398,6 +459,29 @@ const
         }
         
         /**
+         * Removes cached texture sources for an unloaded asset alias.
+         *
+         * @method platypus.PIXIAnimation.invalidateTextureSources
+         * @param {*} alias Asset alias or path used when the texture was cached.
+         */
+        static invalidateTextureSources (alias) {
+            const
+                aliases = getTextureSourceAliases(alias),
+                cacheKey = getTextureCacheKey(alias);
+            let i = aliases.length;
+
+            if (aliases.indexOf(cacheKey) === -1) {
+                aliases.push(cacheKey);
+            }
+
+            while (i--) {
+                delete textureSourceCache[aliases[i]];
+            }
+
+            arrayCache.recycle(aliases);
+        }
+
+        /**
          * This method formats a provided value into a valid PIXIAnimation Sprite Sheet. This includes accepting the EaselJS spec, strings mapping to Platypus sprite sheets, or arrays of either.
          *
          * @method platypus.PIXIAnimation.formatSpriteSheet
@@ -406,7 +490,6 @@ const
          */
         static formatSpriteSheet (spriteSheet) {
             const
-                imageParts = /([\w-\.]+)\.(\w+)$/,
                 addAnimations = function (source = {}, destination, speedRatio, firstFrameIndex, id) {
                     const
                         keys = Object.keys(source),
@@ -458,7 +541,6 @@ const
                         ));
                     }
                 },
-                createId = (images) => images.map((image) => (image.src ?? image).substring(0, MAX_KEY_LENGTH_PER_IMAGE)).join(','),
                 format = function (source, destination) {
                     const
                         {
@@ -479,11 +561,8 @@ const
                         firstImageIndex = dImages.length,
                         firstFrameIndex = dFrames.length;
                     
-                    // Set up id
-                    if (dID) {
-                        destination.id = `${dID};${sID ?? createId(sImages)}`;
-                    } else {
-                        destination.id = sID ?? createId(sImages);
+                    if (sID) {
+                        destination.id = dID ? `${dID};${sID}` : sID;
                     }
                     
                     // Set up images array
@@ -546,7 +625,7 @@ const
                 formatImages = function (name) {
                     if (typeof name === 'string') {
                         const
-                            match = name.match(imageParts);
+                            match = name.match(imageBasename);
 
                         if (match) {
                             return match[1];

--- a/src/components/LevelBuilder.js
+++ b/src/components/LevelBuilder.js
@@ -6,6 +6,176 @@ import {inflate} from 'pako';
 import TiledLoader from './TiledLoader.js';
 
 const
+    assertLevelPiece = function (piece, label) {
+        if (piece == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is undefined. Check that it is defined in platypus.game.settings.levels or levelPieces.`);
+        }
+
+        if (typeof piece !== 'object') {
+            throw new Error(`Level Builder: Level piece "${label}" must be a level definition object, received ${typeof piece}.`);
+        }
+
+        if (piece.width == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is missing width.`);
+        }
+
+        if (piece.height == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is missing height.`);
+        }
+
+        if (piece.tilewidth == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is missing tilewidth.`);
+        }
+
+        if (piece.tileheight == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is missing tileheight.`);
+        }
+
+        if (piece.layers == null) {
+            throw new Error(`Level Builder: Level piece "${label}" is missing a layers array.`);
+        }
+
+        if (!Array.isArray(piece.layers)) {
+            throw new Error(`Level Builder: Level piece "${label}" layers must be an array.`);
+        }
+
+        return piece;
+    },
+    assertLevelTemplate = function (template) {
+        if (template == null) {
+            throw new Error(`Level Builder: levelTemplate is required but was not provided.`);
+        }
+
+        if (!Array.isArray(template)) {
+            throw new Error(`Level Builder: levelTemplate must be an array, received ${typeof template}.`);
+        }
+
+        if (template.length === 0) {
+            throw new Error(`Level Builder: levelTemplate cannot be empty.`);
+        }
+
+        let rowLength = null;
+
+        for (let i = 0; i < template.length; i++) {
+            const
+                row = template[i];
+
+            if (typeof row === 'string') {
+                if (!row) {
+                    throw new Error(`Level Builder: levelTemplate[${i}] is an empty string.`);
+                }
+
+                if (rowLength != null && rowLength !== '1d') {
+                    throw new Error(`Level Builder: levelTemplate is not rectangular: row 0 has ${rowLength} columns but row ${i} is a string.`);
+                }
+
+                rowLength = '1d';
+            } else if (Array.isArray(row)) {
+                if (row.length === 0) {
+                    throw new Error(`Level Builder: levelTemplate row ${i} is empty.`);
+                }
+
+                if (rowLength === '1d') {
+                    throw new Error(`Level Builder: levelTemplate is not rectangular: row 0 is a string but row ${i} is an array.`);
+                }
+
+                if (rowLength == null) {
+                    rowLength = row.length;
+                } else if (rowLength !== row.length) {
+                    throw new Error(`Level Builder: levelTemplate is not rectangular: row 0 has ${rowLength} columns but row ${i} has ${row.length}.`);
+                }
+
+                for (let j = 0; j < row.length; j++) {
+                    if (typeof row[j] !== 'string') {
+                        throw new Error(`Level Builder: levelTemplate[${i}][${j}] must be a piece id string, received ${typeof row[j]}.`);
+                    }
+
+                    if (!row[j]) {
+                        throw new Error(`Level Builder: levelTemplate[${i}][${j}] is an empty string.`);
+                    }
+                }
+            } else {
+                throw new Error(`Level Builder: levelTemplate[${i}] must be a string or array of strings, received ${typeof row}.`);
+            }
+        }
+
+        return template;
+    },
+    assertLevelPieces = function (pieces) {
+        if (pieces == null) {
+            return;
+        }
+
+        if (typeof pieces !== 'object' || Array.isArray(pieces)) {
+            throw new Error(`Level Builder: levelPieces must be an object, received ${Array.isArray(pieces) ? 'array' : typeof pieces}.`);
+        }
+
+        const
+            keys = Object.keys(pieces),
+            {length} = keys;
+
+        for (let i = 0; i < length; i++) {
+            const
+                key = keys[i],
+                value = pieces[key];
+
+            if (typeof value === 'string') {
+                if (!value) {
+                    throw new Error(`Level Builder: levelPieces["${key}"] is an empty string.`);
+                }
+            } else if (Array.isArray(value)) {
+                if (value.length === 0) {
+                    throw new Error(`Level Builder: levelPieces["${key}"] is an empty array. Provide at least one level piece id.`);
+                }
+
+                for (let j = 0; j < value.length; j++) {
+                    if (typeof value[j] !== 'string') {
+                        throw new Error(`Level Builder: levelPieces["${key}"][${j}] must be a string level id, received ${typeof value[j]}.`);
+                    }
+
+                    if (!value[j]) {
+                        throw new Error(`Level Builder: levelPieces["${key}"][${j}] is an empty string.`);
+                    }
+                }
+            } else {
+                throw new Error(`Level Builder: levelPieces["${key}"] must be a string or array of strings, received ${typeof value}.`);
+            }
+        }
+    },
+    resolveLevelPiece = function (piece, label) {
+        if (typeof piece === 'string') {
+            const
+                levelDefinitions = platypus.game.settings.levels,
+                transformIndex = piece.indexOf(':');
+            let levelDefinition = levelDefinitions?.[piece];
+
+            if (!levelDefinition && transformIndex >= 0) {
+                const
+                    baseLabel = piece.substring(0, transformIndex),
+                    transform = piece.substring(transformIndex + 1);
+
+                levelDefinition = levelDefinitions?.[baseLabel];
+
+                if (!levelDefinition) {
+                    throw new Error(`Level Builder: Level piece "${baseLabel}" (from "${piece}") was not found in platypus.game.settings.levels.`);
+                }
+
+                if (transform === 'mirror') {
+                    return levelDefinitions[piece] = mirrorSegment(assertLevelPiece(levelDefinition, baseLabel));
+                }
+
+                throw new Error(`Level Builder: Unknown transform "${transform}" in level piece "${piece}". Supported transforms: mirror.`);
+            }
+
+            if (!levelDefinition) {
+                throw new Error(`Level Builder: Level piece "${piece}" was not found in platypus.game.settings.levels.`);
+            }
+
+            return assertLevelPiece(levelDefinition, piece);
+        }
+
+        return assertLevelPiece(piece, label);
+    },
     maskXFlip = 0x80000000,
     decodeString = (str, index) => (((str.charCodeAt(index)) + (str.charCodeAt(index + 1) << 8) + (str.charCodeAt(index + 2) << 16) + (str.charCodeAt(index + 3) << 24 )) >>> 0),
     decodeArray = (arr, index) => ((arr[index] + (arr[index + 1] << 8) + (arr[index + 2] << 16) + (arr[index + 3] << 24 )) >>> 0),
@@ -25,7 +195,11 @@ const
         
         return arr;
     },
-    decodeLayer = function (layer) {
+    decodeLayer = function (layer, label) {
+        if (layer == null) {
+            throw new Error(`Level Builder: Cannot decode layer${label ? ` in "${label}"` : ''}: layer is undefined.`);
+        }
+
         if (layer.encoding === 'base64') {
             layer.data = decodeBase64(layer.data, layer.compression);
             layer.encoding = 'csv'; // So we won't have to decode again.
@@ -81,8 +255,8 @@ const
         }
         return list;
     },
-    mergeSegment  = function (level, segment, mergeAxis) {
-        segment = cloneLevelDefinition(segment);
+    mergeSegment  = function (level, segment, mergeAxis, segmentLabel) {
+        segment = cloneLevelDefinition(assertLevelPiece(segment, segmentLabel ?? 'segment'));
 
         if (!level.tilewidth && !level.tileheight) {
             //set level tile size data if it's not already set.
@@ -107,9 +281,13 @@ const
         }
 
         for (let i = 0; i < segment.layers.length; i++) {
+            if (segment.layers[i] == null) {
+                throw new Error(`Level Builder: Level piece "${segmentLabel ?? 'segment'}" layer ${i} is undefined.`);
+            }
+
             if (!level.layers[i]) {
                 //if the level doesn't have a layer yet, we're creating it and then copying it from the segment.
-                decodeLayer(segment.layers[i]);
+                decodeLayer(segment.layers[i], segmentLabel);
                 
                 const
                     layer = level.layers[i] = cloneLevelDefinition(segment.layers[i]);
@@ -126,7 +304,7 @@ const
                 //if the level does have a layer, we're appending the new data to it.
                 if (level.layers[i].data && segment.layers[i].data) {
                     // Make sure we're not trying to merge compressed levels.
-                    decodeLayer(segment.layers[i]);
+                    decodeLayer(segment.layers[i], segmentLabel);
                     
                     if (mergeAxis === 'horizontal') {
                         level.layers[i].data = mergeData(level.layers[i].data, level.width, segment.layers[i].data, segment.width, level.height, mergeAxis);
@@ -169,7 +347,6 @@ const
     },
     mergeLevels = function (levelSegments) {
         const
-            levelDefinitions = platypus.game.settings.levels,
             level = {
                 height: 0,
                 width: 0,
@@ -184,35 +361,25 @@ const
                     layers: []
                 };
 
-            for (let j = 0; j < levelSegments[i].length; j++) {
-                //Merge horizontally
-                if (typeof levelSegments[i][j] === 'string') {
-                    const
-                        levelDefinitionLabel = levelSegments[i][j],
-                        transformIndex = levelDefinitionLabel.indexOf(':');
-                    let levelDefinition = levelDefinitions[levelDefinitionLabel];
-                    
-                    // check for transform
-                    if (!levelDefinition && (transformIndex >= 0)) {
-                        const transform = levelDefinitionLabel.substring(transformIndex + 1);
+            if (!Array.isArray(levelSegments[i])) {
+                throw new Error(`Level Builder: mergeLevels row ${i} must be an array of level pieces, received ${typeof levelSegments[i]}.`);
+            }
 
-                        levelDefinition = levelDefinitions[levelDefinitionLabel.substring(0, transformIndex)];
-                        if (transform === 'mirror') {
-                            levelDefinition = levelDefinitions[levelDefinitionLabel] = mirrorSegment(levelDefinition);
-                        }
-                    }
-                    mergeSegment(row, levelDefinition, 'horizontal');
-                } else {
-                    mergeSegment(row, levelSegments[i][j], 'horizontal');
-                }
+            for (let j = 0; j < levelSegments[i].length; j++) {
+                const
+                    piece = levelSegments[i][j],
+                    pieceLabel = typeof piece === 'string' ? piece : `row ${i}, column ${j}`;
+
+                //Merge horizontally
+                mergeSegment(row, resolveLevelPiece(piece, pieceLabel), 'horizontal', pieceLabel);
             }
             //Then merge vertically
-            mergeSegment(level, row, 'vertical');
+            mergeSegment(level, row, 'vertical', `row ${i}`);
         }
         return level;
     },
-    mirrorSegment = function (segment) {
-        segment = cloneLevelDefinition(segment);
+    mirrorSegment = function (segment, segmentLabel) {
+        segment = cloneLevelDefinition(assertLevelPiece(segment, segmentLabel ?? 'segment'));
 
         const
             newSegment = {
@@ -221,7 +388,11 @@ const
             width = segment.width * segment.tilewidth;
 
         for (let i = 0; i < segment.layers.length; i++) {
-            decodeLayer(segment.layers[i]);
+            if (segment.layers[i] == null) {
+                throw new Error(`Level Builder: Level piece "${segmentLabel ?? 'segment'}" layer ${i} is undefined.`);
+            }
+
+            decodeLayer(segment.layers[i], segmentLabel);
 
             const
                 fromLayer = segment.layers[i],
@@ -369,6 +540,8 @@ export default createComponentClass(/** @lends platypus.components.LevelBuilder.
             this.levelMessage.persistentData = data;
             this.levelTemplate = data?.levelTemplate ?? this.levelTemplate;
             this.useUniques = data?.useUniques ?? this.useUniques;
+            assertLevelPieces(piecesToCopy);
+
             this.levelPieces = {};
             if (piecesToCopy) {
                 const
@@ -385,32 +558,26 @@ export default createComponentClass(/** @lends platypus.components.LevelBuilder.
                         this.levelPieces[key] = [
                             ...piecesToCopy[key]
                         ];
-                    } else {
-                        throw ('Level Builder: Level pieces of incorrect type: ' + piecesToCopy[key]);
                     }
                 }
             }
 
             if (this.levelTemplate) {
-                if (this.levelTemplate) {
-                    this.levelMessage.level = [];
-                    for (let i = 0; i < this.levelTemplate.length; i++) {
-                        const
-                            templateRow = this.levelTemplate[i];
+                assertLevelTemplate(this.levelTemplate);
 
-                        if (typeof templateRow === "string") {
-                            this.levelMessage.level[i] = this.getLevelPiece(templateRow);
-                        } else if (templateRow.length) {
-                            this.levelMessage.level[i] = [];
-                            for (let j = 0; j < templateRow.length; j++) {
-                                this.levelMessage.level[i][j] = this.getLevelPiece(templateRow[j]);
-                            }
-                        } else {
-                            throw ('Level Builder: Template row is neither a string or array. What is it?');
+                this.levelMessage.level = [];
+                for (let i = 0; i < this.levelTemplate.length; i++) {
+                    const
+                        templateRow = this.levelTemplate[i];
+
+                    if (typeof templateRow === "string") {
+                        this.levelMessage.level[i] = this.getLevelPiece(templateRow);
+                    } else {
+                        this.levelMessage.level[i] = [];
+                        for (let j = 0; j < templateRow.length; j++) {
+                            this.levelMessage.level[i][j] = this.getLevelPiece(templateRow[j]);
                         }
                     }
-                } else {
-                    platypus.debug.warn('Level Builder: Template is not defined');
                 }
             } else {
                 platypus.debug.warn('Level Builder: There is no level template.');
@@ -452,6 +619,10 @@ export default createComponentClass(/** @lends platypus.components.LevelBuilder.
     
     methods: {// These are methods that are called by this component.
         getLevelPiece: function (type) {
+            if (type == null || type === '') {
+                throw new Error(`Level Builder: Template references an invalid piece id: ${type}.`);
+            }
+
             const
                 pieces = this.levelPieces[type] ?? type;
             

--- a/src/components/Render.js
+++ b/src/components/Render.js
@@ -178,11 +178,17 @@ export default createComponentClass(/** @lends platypus.components.RenderSprite.
     
     getAssetList (a, b, c) {
         const
-            image = a?.image ?? b?.image ?? c?.image;
+            image = a?.image ?? b?.image ?? c?.image,
+            formatImageAsset = (src) => {
+                const
+                    alias = platypus.assetCache?.getFileId ? platypus.assetCache.getFileId(src) : src;
 
-        return (image ? [image] : a?.images ?? b?.images ?? c?.images ?? []).map((src) => ({
-            alias: [src],
-            src
-        }));
+                return {
+                    alias: [alias],
+                    src
+                };
+            };
+
+        return (image ? [image] : a?.images ?? b?.images ?? c?.images ?? []).map(formatImageAsset);
     }
 });

--- a/src/components/RenderSprite.js
+++ b/src/components/RenderSprite.js
@@ -489,12 +489,21 @@ export default createComponentClass(/** @lends platypus.components.RenderSprite.
     
     getAssetList: (function () {
         const
+            formatImageAsset = function (src) {
+                const
+                    alias = platypus.assetCache?.getFileId ? platypus.assetCache.getFileId(src) : src;
+
+                return {
+                    alias: [alias],
+                    src
+                };
+            },
             getImages = function (ss, spriteSheets) {
                 if (ss) {
                     if (typeof ss === 'string') {
                         return getImages(spriteSheets[ss], spriteSheets);
                     } else if (ss.images) {
-                        return greenSlice(ss.images);
+                        return greenSlice(ss.images).map(formatImageAsset);
                     }
                 }
 

--- a/test/unit/PIXIAnimation.test.js
+++ b/test/unit/PIXIAnimation.test.js
@@ -1,0 +1,130 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import {TextureSource} from 'pixi.js';
+import PIXIAnimation from '../../src/PIXIAnimation.js';
+
+function makeTextureSource () {
+    return new TextureSource({});
+}
+
+describe('PIXIAnimation', () => {
+    beforeEach(() => {
+        globalThis.platypus = {
+            assetCache: {
+                getFileId (path) {
+                    const match = path.match(/(?:([^\/?]+?)(?:\.(\w+))?)$/);
+
+                    return match ? match[1] : path;
+                },
+                get (alias) {
+                    if (this.assets?.[alias]) {
+                        return this.assets[alias];
+                    }
+
+                    const fileId = this.getFileId(alias);
+
+                    if (fileId !== alias && this.assets?.[fileId]) {
+                        return this.assets[fileId];
+                    }
+
+                    return null;
+                },
+                assets: {}
+            },
+            debug: {
+                warn: vi.fn()
+            },
+            game: {
+                settings: {
+                    spriteSheets: {}
+                }
+            }
+        };
+    });
+
+    describe('formatSpriteSheet cache ids', () => {
+        it('assigns distinct hashed ids to similarly-formed sprite sheets', () => {
+            platypus.assetCache.assets = {
+                'sheet-a': {source: makeTextureSource()}
+            };
+
+            const
+                definitionA = {
+                    images: ['sheet-a.png'],
+                    frames: [[0, 0, 10, 10, 0, 5, 5]],
+                    animations: {default: 0}
+                },
+                definitionB = {
+                    images: ['sheet-a.png'],
+                    frames: [[0, 0, 10, 10, 0, 5, 6]],
+                    animations: {default: 0}
+                },
+                sheetA = PIXIAnimation.formatSpriteSheet(definitionA),
+                sheetB = PIXIAnimation.formatSpriteSheet(definitionB);
+
+            new PIXIAnimation(sheetA, 'default');
+            new PIXIAnimation(sheetB, 'default');
+
+            expect(sheetA.id).toBeFalsy();
+            expect(sheetB.id).toBeFalsy();
+            expect(sheetA).not.toEqual(sheetB);
+        });
+
+        it('preserves an explicit sprite sheet id', () => {
+            platypus.assetCache.assets = {
+                'sheet-a': {source: makeTextureSource()}
+            };
+
+            const sheet = PIXIAnimation.formatSpriteSheet({
+                id: 'custom-sheet',
+                images: ['sheet-a.png'],
+                frames: [[0, 0, 10, 10, 0, 5, 5]],
+                animations: {default: 0}
+            });
+
+            new PIXIAnimation(sheet, 'default');
+
+            expect(sheet.id).toBe('custom-sheet');
+        });
+    });
+
+    describe('invalidateTextureSources', () => {
+        it('clears stale texture sources when an asset is unloaded', () => {
+            const
+                firstSource = makeTextureSource(),
+                secondSource = makeTextureSource(),
+                sheet = {
+                    images: ['panel.png'],
+                    frames: [[0, 0, 10, 10, 0, 5, 5]],
+                    animations: {default: 0}
+                };
+
+            platypus.assetCache.assets = {
+                panel: {source: firstSource}
+            };
+
+            PIXIAnimation.formatSpriteSheet(sheet);
+            expect(platypus.debug.warn).not.toHaveBeenCalled();
+
+            platypus.assetCache.assets.panel = {source: secondSource};
+
+            PIXIAnimation.formatSpriteSheet({
+                images: ['panel.png'],
+                frames: [[0, 0, 10, 10, 0, 5, 5]],
+                animations: {default: 0}
+            });
+            expect(platypus.debug.warn).not.toHaveBeenCalled();
+
+            delete platypus.assetCache.assets.panel;
+            PIXIAnimation.invalidateTextureSources('panel.png');
+
+            platypus.assetCache.assets.panel = {source: secondSource};
+
+            PIXIAnimation.formatSpriteSheet({
+                images: ['panel.png'],
+                frames: [[0, 0, 10, 10, 0, 5, 5]],
+                animations: {default: 0}
+            });
+            expect(platypus.debug.warn).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/unit/components/LevelBuilder.test.js
+++ b/test/unit/components/LevelBuilder.test.js
@@ -1,5 +1,6 @@
 import {beforeEach, describe, expect, it} from 'vitest';
 import LevelBuilder from '../../../src/components/LevelBuilder.js';
+import Messenger from '../../../src/Messenger.js';
 
 function makePiece ({width, height, tile, objectX = 0, objectY = 0}) {
     return {
@@ -37,10 +38,7 @@ function makePiece ({width, height, tile, objectX = 0, objectY = 0}) {
 }
 
 function makeBuilder () {
-    return new LevelBuilder({
-        on () {},
-        triggerEvent () {}
-    }, {});
+    return new LevelBuilder(new Messenger(), {});
 }
 
 describe('LevelBuilder mergeLevels', () => {
@@ -121,3 +119,95 @@ describe('LevelBuilder mergeLevels', () => {
         expect(stored.layers[0].data[0]).toBe(3);
     });
 });
+
+describe('LevelBuilder validation errors', () => {
+    beforeEach(() => {
+        globalThis.platypus = {
+            game: {
+                settings: {
+                    levels: {}
+                }
+            },
+            debug: {
+                warn () {}
+            }
+        };
+    });
+
+    it('throws when merging an undefined level piece by name', () => {
+        const builder = makeBuilder();
+
+        expect(() => builder.mergeLevels([['missing-piece']])).toThrow(
+            'Level piece "missing-piece" was not found in platypus.game.settings.levels.'
+        );
+    });
+
+    it('throws when merging a level piece missing tilewidth', () => {
+        const builder = makeBuilder();
+
+        expect(() => builder.mergeLevels([[{width: 1, height: 1, layers: []}]])).toThrow(
+            'Level piece "row 0, column 0" is missing tilewidth.'
+        );
+    });
+
+    it('throws when levelPieces entry has an invalid type', () => {
+        const builder = makeBuilder();
+
+        expect(() => triggerLayerLoaded(builder, {
+            levelPieces: {forest: 42},
+            levelTemplate: ['forest']
+        })).toThrow(
+            'levelPieces["forest"] must be a string or array of strings, received number.'
+        );
+    });
+
+    it('throws when levelTemplate row is empty', () => {
+        const builder = makeBuilder();
+
+        expect(() => triggerLayerLoaded(builder, {
+            levelTemplate: [[]]
+        })).toThrow(
+            'levelTemplate row 0 is empty.'
+        );
+    });
+
+    it('throws when levelTemplate is not rectangular', () => {
+        const builder = makeBuilder();
+
+        expect(() => triggerLayerLoaded(builder, {
+            levelTemplate: [['start', 'end'], ['only-one']],
+            levelPieces: {start: 'a', end: 'b', 'only-one': 'c'}
+        })).toThrow(
+            'levelTemplate is not rectangular: row 0 has 2 columns but row 1 has 1.'
+        );
+    });
+
+    it('throws when a levelPieces mapping points to a missing level', () => {
+        const builder = makeBuilder();
+
+        expect(() => triggerLayerLoaded(builder, {
+            levelTemplate: [['forest']],
+            levelPieces: {forest: 'missing-map'}
+        })).toThrow(
+            'Level piece "missing-map" was not found in platypus.game.settings.levels.'
+        );
+    });
+
+    it('throws when useUniques exhausts piece options', () => {
+        const builder = makeBuilder();
+
+        platypus.game.settings.levels['forest-1'] = makePiece({width: 1, height: 1, tile: 1});
+
+        expect(() => triggerLayerLoaded(builder, {
+            levelTemplate: ['forest', 'forest'],
+            levelPieces: {forest: ['forest-1']},
+            useUniques: true
+        })).toThrow(
+            'There are no MORE level pieces of type: forest'
+        );
+    });
+});
+
+function triggerLayerLoaded (builder, data = {}) {
+    builder.owner.triggerEvent('layer-loaded', data);
+}


### PR DESCRIPTION
### Added

- **PIXIAnimation:** `invalidateTextureSources` clears cached texture sources when an asset is unloaded.
- Unit tests for `PIXIAnimation` sprite sheet cache ids and texture source invalidation.

### Fixed

- **LevelBuilder:** Throws informative errors when `levelPieces` or `levelTemplate` are incomplete or invalid (missing levels, empty rows, non-rectangular templates, incomplete level definitions) instead of generic undefined property errors.
- **PIXIAnimation:** Resolves texture assets by full path or image basename; updates cached texture sources when the underlying asset changes; sprite sheet cache ids use content hashes instead of truncated JSON to avoid collisions.
- **AssetManager:** Invalidates `PIXIAnimation` texture sources when unloading assets.
- **Render / RenderSprite:** `getAssetList` registers image aliases via `getFileId` for webpack URL resolution.